### PR TITLE
Merge branch feature/http-1.0

### DIFF
--- a/Net/HttpServer.cs
+++ b/Net/HttpServer.cs
@@ -236,13 +236,6 @@ namespace McSherry.Zener.Net
 
             NetworkStream ns = tcl.GetStream();
 
-
-            /* TODO: Implement code to determine which serialiser to use.
-             */
-            //HttpSerialiser httpSer = new Rfc7230Serialiser(res, ns);
-            //HttpDeserialiser httpDes = new Http1Deserialiser(ns);
-
-
             HttpRequest req;
             HttpDeserialiser httpDes;
             HttpResponse res;

--- a/Net/Serialisation/HttpSerialiser.cs
+++ b/Net/Serialisation/HttpSerialiser.cs
@@ -168,8 +168,9 @@ namespace McSherry.Zener.Net.Serialisation
                         **/
                         default:
                         /* RFC 7230 is the first (of several) RFCs that
-                         * specify HTTP/1.1. We're using RFC naming to
-                         * avoid hard-to-read class names. Consider:
+                         * specify HTTP/1.1, and RFC 2616 is the analogue
+                         * for HTTP/1.0. We're using RFC naming to avoid
+                         * hard-to-read class names. Consider:
                          * 
                          *      +------------------+-------------------+
                          *      |     Version      |        RFC        |
@@ -183,6 +184,7 @@ namespace McSherry.Zener.Net.Serialisation
                          * would argue that RFC-based class names are
                          * easier to read when you know what you're after.
                         **/
+                        case 0: return new Rfc2616Serialiser(response, output);
                         case 1: return new Rfc7230Serialiser(response, output);
                     }
                 }

--- a/Net/Serialisation/Rfc2616Serialiser.cs
+++ b/Net/Serialisation/Rfc2616Serialiser.cs
@@ -1,0 +1,24 @@
+﻿/*
+ *      Copyright (c) 2014-2015, Liam McSherry
+ *      All Rights reserved.
+ *      
+ *      Released under BSD 3-Clause licence. See terms in
+ *      /LICENCE, or online: http://opensource.org/licenses/BSD-3-Clause
+ */
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace McSherry.Zener.Net.Serialisation
+{
+    /// <summary>
+    /// A class for serialising an HttpResponse instance to
+    /// an HTTP/1.0 (RFC 2616) response.
+    /// </summary>
+    public sealed class Rfc2616Serialiser
+        : Rfc7230Serialiser, IDisposable
+    {
+        
+    }
+}

--- a/Net/Serialisation/Rfc2616Serialiser.cs
+++ b/Net/Serialisation/Rfc2616Serialiser.cs
@@ -37,7 +37,7 @@ namespace McSherry.Zener.Net.Serialisation
         /// implementations of Rfc2616Serialiser subclasses.
         /// </summary>
         /// <param name="request">The request to evaluate.</param>
-        protected void Rfc2616IntlConfigure(HttpRequest request)
+        private void Rfc2616IntlConfigure(HttpRequest request)
         {
             // If the client supports chunked encoding, it will indicate
             // it in its 'TE' header. HTTP/1.0 clients are not required, and
@@ -92,6 +92,11 @@ namespace McSherry.Zener.Net.Serialisation
         public Rfc2616Serialiser(HttpResponse response, Stream output)
             : base(response, output)
         {
+            // Make sure we set the superclass's HttpVersion properly.
+            // Rfc7230Serialiser uses this to send the version to the
+            // client.
+            base.HttpVersion = new Version(1, 0);
+
             // Client's aren't required to support chunked encoding, so
             // we prevent the enabling of chunked encoding by default.
             _supportsChunked = false;

--- a/Net/Serialisation/Rfc7230Serialiser.cs
+++ b/Net/Serialisation/Rfc7230Serialiser.cs
@@ -214,22 +214,21 @@ namespace McSherry.Zener.Net.Serialisation
             // The client indicates this via its 'Connection' header.
             var connHdr = request.Headers[Headers.Connection].LastOrDefault();
             // If the client hasn't sent an HTTP header, we don't have to make
-            // any changes because we have defaulted to closing the connection.
+            // any changes because we have defaulted to keeping the connection
+            // alive, which is the default action in HTTP/1.1.
             if (connHdr != default(HttpHeader))
             {
                 // If the value of the 'Connection' header sent to us by the
-                // client equals 'keep-alive', we'll set the value of our
-                // property Connection to KeepAlive instead of the default Close.
-                if (connHdr.Value.Equals(
+                // client is not 'keep-alive', we treat the connection as
+                // non-persistent and set it to be closed after the response
+                // is sent.
+                if (!connHdr.Value.Equals(
                     value:          HttpConnection.KeepAlive.GetValue(),
                     comparisonType: StringComparison.OrdinalIgnoreCase
                     ))
                 {
-                    this.Connection = HttpConnection.KeepAlive;
+                    this.Connection = HttpConnection.Close;
                 }
-
-                // If we haven't made any changes above, we don't need to do
-                // anything special as we already default to 'close'.
             }
         }
 
@@ -280,13 +279,10 @@ namespace McSherry.Zener.Net.Serialisation
             _useCompression = false;
             _compressor = null;
             // As we haven't been provided with an HttpRequest, we don't
-            // know whether the client deems persistent connections acceptable,
-            // so we default to closing them.
-            //
-            // This default value has the added benefit of improving HTTP/1.0
-            // client compatibility, as 1.0 clients may not support persistent
-            // connections, and so may not send a 'Connection' header.
-            _connection = HttpConnection.Close;
+            // know whether the client deems persistent connections acceptable.
+            // HTTP/1.1 requires that, unless otherwise specified, all connections
+            // be treated as persistent.
+            _connection = HttpConnection.KeepAlive;
             // We're disabling output buffering by default, as it doing
             // so will generally provide better performance. Output buffering
             // being disabled means we'll be sending using chunked encoding,

--- a/Net/Serialisation/Rfc7230Serialiser.cs
+++ b/Net/Serialisation/Rfc7230Serialiser.cs
@@ -134,7 +134,7 @@ namespace McSherry.Zener.Net.Serialisation
         /// implementations of Rfc7230Serialiser subclasses.
         /// </summary>
         /// <param name="request">The request to evaluate.</param>
-        protected void IntlConfigure(HttpRequest request)
+        protected void Rfc7230IntlConfigure(HttpRequest request)
         {
             if (request == null)
             {
@@ -433,7 +433,7 @@ namespace McSherry.Zener.Net.Serialisation
         /// </exception>
         public override void Configure(HttpRequest request)
         {
-            this.IntlConfigure(request);
+            this.Rfc7230IntlConfigure(request);
         }
 
         /// <summary>

--- a/Net/Serialisation/Rfc7230Serialiser.cs
+++ b/Net/Serialisation/Rfc7230Serialiser.cs
@@ -134,8 +134,8 @@ namespace McSherry.Zener.Net.Serialisation
         protected bool _bodyWritten;
 
         /// <summary>
-        /// Rfc7230Serialiser's implementation of EvaluateClient
-        /// as a protected method so it can be called in EvaluateClient
+        /// Rfc7230Serialiser's implementation of Configure
+        /// as a protected method so it can be called in Configure
         /// implementations of Rfc7230Serialiser subclasses.
         /// </summary>
         /// <param name="request">The request to evaluate.</param>

--- a/Net/Serialisation/Rfc7230Serialiser.cs
+++ b/Net/Serialisation/Rfc7230Serialiser.cs
@@ -96,7 +96,7 @@ namespace McSherry.Zener.Net.Serialisation
         /// <summary>
         /// The format string used for the response line.
         /// </summary>
-        private const string ResponseLineFormat = "HTTP/1.1 {0} {1}\r\n";
+        private const string ResponseLineFormat = "HTTP/{0} {1} {2}\r\n";
         /// <summary>
         /// The format string used for HTTP/1.1 headers.
         /// </summary>
@@ -233,6 +233,16 @@ namespace McSherry.Zener.Net.Serialisation
         }
 
         /// <summary>
+        /// The HTTP version to be used in the response headers. Defaults
+        /// to 1.1.
+        /// </summary>
+        protected virtual Version HttpVersion
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// The stream we'll buffer output to.
         /// </summary>
         protected MemoryStream _outputBuffer;
@@ -272,6 +282,8 @@ namespace McSherry.Zener.Net.Serialisation
         public Rfc7230Serialiser(HttpResponse response, Stream output)
             : base(response, output)
         {
+            this.HttpVersion = new Version(1, 1);
+
             // We haven't been provided with an HttpRequest, so it
             // isn't possible for us to determine whether the client
             // supports compression.
@@ -707,6 +719,7 @@ namespace McSherry.Zener.Net.Serialisation
                 byte[] hbuf = Encoding.ASCII
                     .GetBytes(String.Format(
                         ResponseLineFormat,
+                        this.HttpVersion.ToString(2),
                         base.Response.StatusCode.GetCode(),
                         base.Response.StatusCode.GetMessage()
                         ));

--- a/Net/Serialisation/Rfc7230Serialiser.cs
+++ b/Net/Serialisation/Rfc7230Serialiser.cs
@@ -44,6 +44,11 @@ namespace McSherry.Zener.Net.Serialisation
             /// for transfer.
             /// </summary>
             public const string TransferEncoding = "Transfer-Encoding";
+            /// <summary>
+            /// The header used by the client to indicate the transfer
+            /// encoding methods it supports.
+            /// </summary>
+            public const string TE = "TE";
 
             /// <summary>
             /// The header providing the length, in bytes, of the response

--- a/Zener.csproj
+++ b/Zener.csproj
@@ -100,6 +100,7 @@
     <Compile Include="Net\Rfc2045.cs" />
     <Compile Include="Net\Rfc2616.cs" />
     <Compile Include="Net\Rfc3896.cs" />
+    <Compile Include="Net\Serialisation\Rfc2616Serialiser.cs" />
     <Compile Include="Net\Serialisation\Rfc7230Serialiser.cs" />
     <Compile Include="Net\Serialisation\Serialise.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
This branch adds the `Rfc2616Serialiser` class, which improves support for HTTP 1.0 responses, and is related to #49.